### PR TITLE
Fixed runtime error in viewing registered slot

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview --port 5173"
   },
   "dependencies": {
     "@react-three/fiber": "^8.16.8",

--- a/src/pages/book.tsx
+++ b/src/pages/book.tsx
@@ -34,6 +34,11 @@ function SlotSelect({ap, rawSlots}: {ap: App, rawSlots: Slot[]}) {
 
     if (ap.slot !== null) {
         const k = rawSlots.find((sl) => sl.id === ap.slot)
+        if(k === undefined){
+            return (
+                <div>Something went wrong, please go back to the home page and then click "book" on the top right</div>
+            )
+        }
         return (
             <div>Your slot has been booked for <span className="italic">{k!.timing}</span></div>
         )


### PR DESCRIPTION
The error:
![WhatsApp Image 2024-07-04 at 17 15 27_df9e8d90](https://github.com/lugvitc/recruitments/assets/74148176/58c8f229-2e86-40d8-8954-ef7ae7ddb53e)

The fix:
First, I just handled the error and wrote a clearer error page. 
But it turns out that the function (SlotSelect) gets called multiple times already (I don't know why). And since the first (failed) function call no longer gives a runtime error, the next few tries end up with the correct answer. The user neither sees the initial runtime error nor the error page that I wrote.